### PR TITLE
Don't assign team as reviewer

### DIFF
--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -5,8 +5,11 @@ if ! command -v hub; then
   exit 1
 fi
 
-REVIEWER='LabKey/Releasers'
+REVIEWER1='labkey-tchad'
+REVIEWER2='labkey-klum'
 ASSIGNEE='labkey-teamcity'
+# Reference in PR comments. Default action token can't see teams. 
+TEAM='LabKey/releasers'
 
 if [ -z "$GITHUB_SHA" ]; then
 	echo "Commit hash not specified" >&2
@@ -68,7 +71,7 @@ else
 		exit 1
 	fi
 	echo "Create pull request."
-	if ! hub pull-request -f -h "$FF_BRANCH" -b "$RELEASE_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER" \
+	if ! hub pull-request -f -h "$FF_BRANCH" -b "$RELEASE_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER1" -r "$REVIEWER2" \
 		-m "Fast-forward for ${TAG}" \
 		-m "_Generated automatically._" \
 		-m "**Approve all matching PRs simultaneously.**" \
@@ -113,9 +116,9 @@ if git merge --no-ff "$GITHUB_SHA" -m "Merge ${TAG} to ${NEXT_RELEASE}"; then
 		echo "Failed to push merge branch: ${MERGE_BRANCH}" >&2
 		exit 1
 	fi
-	if ! hub pull-request -f -h "$MERGE_BRANCH" -b "$TARGET_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER" \
+	if ! hub pull-request -f -h "$MERGE_BRANCH" -b "$TARGET_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER1" -r "$REVIEWER2" \
 		-m "Merge ${TAG} to ${NEXT_RELEASE}" \
-		-m "_Generated automatically._" \
+		-m "_Generated automatically._ (Attn: ${TEAM})" \
 		-m "**Approve all matching PRs simultaneously.**" \
 		-m "**Approval will trigger automatic merge.**";
 	then
@@ -135,9 +138,9 @@ else
 		exit 1
 	fi
 
-	if ! hub pull-request -f -h "$MERGE_BRANCH" -b "$TARGET_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER" \
+	if ! hub pull-request -f -h "$MERGE_BRANCH" -b "$TARGET_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER1" -r "$REVIEWER2" \
 		-m "Merge ${TAG} to ${NEXT_RELEASE} (Conflicts)" \
-		-m "_Automatic merge failed!_ Please merge '${TARGET_BRANCH}' into '${MERGE_BRANCH}' and resolve conflicts manually." \
+		-m "_Automatic merge failed!_ Please merge '${TARGET_BRANCH}' into '${MERGE_BRANCH}' and resolve conflicts manually. (Attn: ${TEAM})" \
 		-m "**Approve all matching PRs simultaneously.**" \
 		-m "**Approval will trigger automatic merge.**";
 	then

--- a/merge-release/merge_release.sh
+++ b/merge-release/merge_release.sh
@@ -5,7 +5,7 @@ if ! command -v hub; then
   exit 1
 fi
 
-REVIEWER='LabKey/Releasers'
+TEAM='LabKey/releasers'
 
 PR_NUMBER=$1
 MERGE_BRANCH=$2 # ff_19.3.11
@@ -25,6 +25,6 @@ if git merge origin/"$MERGE_BRANCH" -m "Merge ${MERGE_BRANCH} to ${TARGET_BRANCH
 	echo "Merge successful!";
 else
 	echo "Failed to merge!" >&2
-	hub api "repos/{owner}/{repo}/issues/${PR_NUMBER}/comments" --raw-field "body=@${REVIEWER} __ERROR__ Automatic merge failed!"
+	hub api "repos/{owner}/{repo}/issues/${PR_NUMBER}/comments" --raw-field "body=@${TEAM} __ERROR__ Automatic merge failed!"
 	exit 1
 fi


### PR DESCRIPTION
Default `GITHUB_TOKEN` can't see teams