### PR TITLE
Don't attempt merge forward if there are no changes

### DIFF
--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -205,6 +205,7 @@ echo "Merging ${TAG} to ${TARGET_BRANCH}"
 RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${TARGET_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
 if [ -z "${RELEASE_DIFF:-}" ]; then
 	echo "No changes to merge from ${TAG} to ${TARGET_BRANCH}."
+	exit 0
 fi
 
 git config --global user.name "github-actions"

--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -39,6 +39,8 @@ if [ -z "${RELEASE_NUM:-}" ]; then
 	exit 1
 fi
 
+# TODO: Use ${GITHUB_REPOSITORY} == "LabKey/server" to trigger special behavior
+
 # RexEx for extracting branch information from GitHub compare JSON response
 # $> hub api repos/{owner}/{repo}/compare/develop...${GITHUB_SHA}) | grep -oE ${AHEAD_BY_EXP} | cut -d':' -f 2
 AHEAD_BY_EXP='"ahead_by":\d+'
@@ -199,6 +201,11 @@ fi
 
 echo ""
 echo "Merging ${TAG} to ${TARGET_BRANCH}"
+
+RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${TARGET_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
+if [ -z "${RELEASE_DIFF:-}" ]; then
+	echo "No changes to merge from ${TAG} to ${TARGET_BRANCH}."
+fi
 
 git config --global user.name "github-actions"
 git config --global user.email "teamcity@labkey.com"


### PR DESCRIPTION
#### Rationale
We sometimes merge forward outside of the release cycle which causes the normal merge forward to fail when we cut a release.

