### PR TITLE
Enable full bash strict mode

### DIFF
--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -120,7 +120,7 @@ function update_snapshot_version() {
 	fi
 
 	next_version="$(increment_version "${RELEASE_NUM}")-SNAPSHOT"
-	branch="fb_${next_version}"
+	branch="fb_bump_${next_version}"
 
 	git checkout -b "$branch" "$GITHUB_SHA"
 	update_version "$next_version"

--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# bash strict mode (modified) -- http://redsymbol.net/articles/unofficial-bash-strict-mode/
-set -uo pipefail
+# bash strict mode -- http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
 IFS=$'\n\t'
 
 if ! command -v hub; then
@@ -190,33 +190,21 @@ if ! hub api "repos/{owner}/{repo}/branches/${SNAPSHOT_BRANCH}"; then
 	# Initial release branch creation (e.g. TAG=20.7.RC0)
 	echo "Create ${SNAPSHOT_BRANCH} branch."
 	hub api 'repos/{owner}/{repo}/git/refs' --raw-field "ref=refs/heads/${SNAPSHOT_BRANCH}" --raw-field "sha=${GITHUB_SHA}"
-	SNAPSHOT_CREATED="$?"
 	echo ""
 
 	if $SERVER_REPO; then
 		# Don't create non-SNAPSHOT branch for server repository
-		if [ $SNAPSHOT_CREATED == 0 ]; then
-			update_snapshot_version
-			echo "${SNAPSHOT_BRANCH} branch successfully created."
-			exit 0
-		else
-			echo "Failed to create ${SNAPSHOT_BRANCH} branch." >&2
-			exit 1
-		fi
+		update_snapshot_version
+		echo "${SNAPSHOT_BRANCH} branch successfully created."
+		exit 0
 	fi
 
 	echo "Create ${RELEASE_BRANCH} branch."
 	hub api 'repos/{owner}/{repo}/git/refs' --raw-field "ref=refs/heads/${RELEASE_BRANCH}" --raw-field "sha=${GITHUB_SHA}"
-	RELEASE_CREATED="$?"
 	echo ""
 
-	if [ $SNAPSHOT_CREATED == 0 ] && [ $RELEASE_CREATED == 0 ]; then
-		echo "${RELEASE_NUM} branches successfully created."
-		exit 0
-	else
-		echo "Failed to create ${RELEASE_NUM} release branches." >&2
-		exit 1
-	fi
+	echo "${RELEASE_NUM} branches successfully created."
+	exit 0
 fi
 
 if $SERVER_REPO && [ "$PATCH_NUMBER" == "0" ]; then

--- a/merge-release/merge_release.sh
+++ b/merge-release/merge_release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# bash strict mode (modified) -- http://redsymbol.net/articles/unofficial-bash-strict-mode/
-set -uo pipefail
+# bash strict mode -- http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
 IFS=$'\n\t'
 
 if ! command -v hub; then


### PR DESCRIPTION
#### Rationale
Bash strict mode can prevent errors from slipping through undetected. http://redsymbol.net/articles/unofficial-bash-strict-mode/
The only part of strict mode not enabled is the `set -e` flag. Some lines are expected to fail silently (e.g. `PATCH_NUMBER="$( echo "$TAG" | cut -d'.' -f3- | grep -oE '(^[0-9]+$)' )"`). They should be rewritten so that they won't have a non-zero exit code.

#### Related Pull Requests
* #17 

#### Changes
* Add `set -e` flag to branch and merge actions
