### PR TITLE
Don't create 'ff' branch for server repository '.0' release

### DIFF
--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -120,7 +120,7 @@ function update_snapshot_version() {
 	fi
 
 	next_version="$(increment_version "${RELEASE_NUM}")-SNAPSHOT"
-	branch="fb_${next_version}"
+	branch="fb_bot_${next_version}"
 
 	git checkout -b "$branch" "$GITHUB_SHA"
 	update_version "$next_version"
@@ -265,7 +265,7 @@ else
 		echo "No new changes for ${RELEASE_BRANCH} in ${TAG}."
 	else
 		echo "Create fast-forward branch for ${TAG}."
-		FF_BRANCH="${RELEASE_NUM}_ff_${TAG}"
+		FF_BRANCH="${RELEASE_NUM}_ff_bot_${TAG}"
 		if $SERVER_REPO; then
 			# Merging changes from SNAPSHOT to release branch
 			if ! git checkout -b "$FF_BRANCH" --no-track origin/"$RELEASE_BRANCH" || ! git merge --no-commit "$GITHUB_SHA"; then
@@ -319,7 +319,7 @@ if [ -n "${NEXT_RELEASE:-}" ]; then
 	if hub api "repos/{owner}/{repo}/git/refs/heads/${TARGET_BRANCH}"; then
         echo ""
         echo "Next ESR release '${TARGET_BRANCH}' exist. Merging ${TAG} to it."
-		MERGE_BRANCH="${NEXT_RELEASE}_fb_merge_${SOURCE_VERSION}"
+		MERGE_BRANCH="${NEXT_RELEASE}_fb_bot_merge_${SOURCE_VERSION}"
     else
         echo ""
         echo "Next ESR release '${TARGET_BRANCH}' doesn't exist. Consider merging to unreleased monthly version."
@@ -335,7 +335,7 @@ if [ -n "${NEXT_RELEASE:-}" ]; then
                     TARGET_BRANCH=release${NEXT_RELEASE}-SNAPSHOT
                     if hub api "repos/{owner}/{repo}/git/refs/heads/${TARGET_BRANCH}"; then
                         # 'SNAPSHOT' branch exists but '.0' release hasn't been created. Merge to it!
-                        MERGE_BRANCH="${NEXT_RELEASE}_fb_merge_${SOURCE_VERSION}"
+                        MERGE_BRANCH="${NEXT_RELEASE}_fb_bot_merge_${SOURCE_VERSION}"
                     else
                         echo ""
                         echo "${TARGET_BRANCH} doesn't exist. No eligible monthly release to merge to."
@@ -355,7 +355,7 @@ fi
 if [ -z "${MERGE_BRANCH:-}" ]; then
 	TARGET_BRANCH='develop'
 	NEXT_RELEASE='develop'
-	MERGE_BRANCH=fb_merge_${SOURCE_VERSION}
+	MERGE_BRANCH=fb_bot_merge_${SOURCE_VERSION}
 fi
 
 echo ""

--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -219,6 +219,8 @@ if ! hub api "repos/{owner}/{repo}/branches/${SNAPSHOT_BRANCH}"; then
 	fi
 fi
 
+git fetch --unshallow || true
+
 if $SERVER_REPO && [ "$PATCH_NUMBER" == "0" ]; then
 	echo "Create non-SNAPSHOT branch in server repository for '.0' release"
 	git checkout -b "$RELEASE_BRANCH" "$GITHUB_SHA"
@@ -230,71 +232,71 @@ if $SERVER_REPO && [ "$PATCH_NUMBER" == "0" ]; then
 	echo "Move tag to release commit"
 	git tag --force "$TAG"
 	git push --force origin "$TAG"
-fi
 
-# Create branch and PR for final release
-git fetch --unshallow || true
+else
+	# Create branch and PR for final release if necessary
 
-# Make sure tag is valid
-if ! $SERVER_REPO; then # Release branch is expected to be ahead of SNAPSHOT in server repo
-	RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "${GITHUB_SHA}..origin/${RELEASE_BRANCH}" | grep -v -e '^$')"
+	# Make sure tag is valid
+	if ! $SERVER_REPO; then # Release branch is expected to be ahead of SNAPSHOT in server repo
+		RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "${GITHUB_SHA}..origin/${RELEASE_BRANCH}" | grep -v -e '^$')"
+		echo ""
+		if [ -n "$RELEASE_DIFF" ]; then
+			echo "Improper release tag. ${TAG} is $(echo "$RELEASE_DIFF" | wc -l | xargs) commit(s) behind latest release." >&2
+			echo "$RELEASE_DIFF" >&2
+			exit 1
+		fi
+	fi
+	RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${SNAPSHOT_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
 	echo ""
 	if [ -n "$RELEASE_DIFF" ]; then
-		echo "Improper release tag. ${TAG} is $(echo "$RELEASE_DIFF" | wc -l | xargs) commit(s) behind latest release." >&2
+		echo "Improper release tag. ${TAG} is $(echo "$RELEASE_DIFF" | wc -l | xargs) commit(s) ahead of current snapshot branch." >&2
 		echo "$RELEASE_DIFF" >&2
 		exit 1
 	fi
-fi
-RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${SNAPSHOT_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
-echo ""
-if [ -n "$RELEASE_DIFF" ]; then
-	echo "Improper release tag. ${TAG} is $(echo "$RELEASE_DIFF" | wc -l | xargs) commit(s) ahead of current snapshot branch." >&2
-	echo "$RELEASE_DIFF" >&2
-	exit 1
-fi
 
-RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${RELEASE_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
-echo ""
-# Create branch and PR for final release
-if [ -z "${PATCH_NUMBER:-}" ]; then
-	echo "${TAG} does not look like a patch release, just triggering merging forward."
-	echo "Deleting temporary tag"
-	git push origin :"$GITHUB_REF"
-elif [ -z "${RELEASE_DIFF:-}" ] && ! $SERVER_REPO ; then
-	echo "No new changes for ${RELEASE_BRANCH} in ${TAG}."
-else
-	echo "Create fast-forward branch for ${TAG}."
-	FF_BRANCH="${RELEASE_NUM}_ff_${TAG}"
-	if $SERVER_REPO; then
-		# Merging changes from SNAPSHOT to release branch
-		if ! git checkout -b "$FF_BRANCH" --no-track origin/"$RELEASE_BRANCH" || ! git merge --no-commit "$GITHUB_SHA"; then
-			echo "Failed to create branch: ${FF_BRANCH}" >&2
-			exit 1
-		fi
-		update_release_version
-		if ! git push -u origin "$FF_BRANCH"; then
-			echo "Failed to push branch: ${FF_BRANCH}" >&2
-			exit 1
-		fi
-		# Move tag to actual release commit
-		git tag --force "$TAG"
-		git push --force origin "$TAG"
+	RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${RELEASE_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
+	echo ""
+	# Create branch and PR for final release
+	if [ -z "${PATCH_NUMBER:-}" ]; then
+		echo "${TAG} does not look like a patch release, just triggering merging forward."
+		echo "Deleting temporary tag"
+		git push origin :"$GITHUB_REF"
+	elif [ -z "${RELEASE_DIFF:-}" ] && ! $SERVER_REPO ; then
+		echo "No new changes for ${RELEASE_BRANCH} in ${TAG}."
 	else
-		if ! hub api 'repos/{owner}/{repo}/git/refs' --raw-field "ref=refs/heads/${FF_BRANCH}" --raw-field "sha=${GITHUB_SHA}"; then
-			echo "Failed to create branch: ${FF_BRANCH}" >&2
+		echo "Create fast-forward branch for ${TAG}."
+		FF_BRANCH="${RELEASE_NUM}_ff_${TAG}"
+		if $SERVER_REPO; then
+			# Merging changes from SNAPSHOT to release branch
+			if ! git checkout -b "$FF_BRANCH" --no-track origin/"$RELEASE_BRANCH" || ! git merge --no-commit "$GITHUB_SHA"; then
+				echo "Failed to create branch: ${FF_BRANCH}" >&2
+				exit 1
+			fi
+			update_release_version
+			if ! git push -u origin "$FF_BRANCH"; then
+				echo "Failed to push branch: ${FF_BRANCH}" >&2
+				exit 1
+			fi
+			# Move tag to actual release commit
+			git tag --force "$TAG"
+			git push --force origin "$TAG"
+		else
+			if ! hub api 'repos/{owner}/{repo}/git/refs' --raw-field "ref=refs/heads/${FF_BRANCH}" --raw-field "sha=${GITHUB_SHA}"; then
+				echo "Failed to create branch: ${FF_BRANCH}" >&2
+				exit 1
+			fi
+		fi
+		echo "Create pull request."
+		if ! pr_msg "Fast-forward for ${TAG}" \
+			"_Generated automatically._" \
+			"**Approve all matching PRs simultaneously.**" \
+			"**Approval will trigger automatic merge.**" \
+			"View all PRs: https://internal.labkey.com/Scrumtime/Backlog/harvest-gitOpenPullRequests.view?branch=${FF_BRANCH}" \
+			| hub pull-request -f -h "$FF_BRANCH" -b "$RELEASE_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER" -F -;
+		then
+			echo "Failed to create pull request for $FF_BRANCH" >&2
 			exit 1
 		fi
-	fi
-	echo "Create pull request."
-	if ! pr_msg "Fast-forward for ${TAG}" \
-		"_Generated automatically._" \
-		"**Approve all matching PRs simultaneously.**" \
-		"**Approval will trigger automatic merge.**" \
-		"View all PRs: https://internal.labkey.com/Scrumtime/Backlog/harvest-gitOpenPullRequests.view?branch=${FF_BRANCH}" \
-		| hub pull-request -f -h "$FF_BRANCH" -b "$RELEASE_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER" -F -;
-	then
-		echo "Failed to create pull request for $FF_BRANCH" >&2
-		exit 1
 	fi
 fi
 


### PR DESCRIPTION
#### Rationale
We create a `releaseXX.Y` branch in the server repository when we lock in the '.0' release (unlike other repositories, where we create the `releaseXX.Y` along with the `releaseXX.Y-SNAPSHOT` branch). That is causing the script to error out when it attempts to open a PR without any changes to the newly created `releaseXX.Y` branch.
Additionally, it would be useful to give the branches created by these scripts a distinct naming scheme to allow us to configure TeamCity to not flood the queue every time we release.

#### Changes
* Don't create 'ff' branch for server repository on '.0' release
* Add 'bot_' to branch names to allow TeamCity to identify them