### PR TITLE
Prevent collisions between triggered merges

### DIFF
--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -221,83 +221,88 @@ fi
 
 git fetch --unshallow || true
 
-if $SERVER_REPO && [ "$PATCH_NUMBER" == "0" ]; then
-	echo "Create non-SNAPSHOT branch in server repository for '.0' release"
-	git checkout -b "$RELEASE_BRANCH" "$GITHUB_SHA"
-	update_release_version
-	if ! git push -u origin "$RELEASE_BRANCH"; then
-		echo "Failed create ${RELEASE_BRANCH} for ${TAG}." >&2
-		exit 1
-	fi
-	echo "Move tag to release commit"
-	git tag --force "$TAG"
-	git push --force origin "$TAG"
-
+if [ -z "${PATCH_NUMBER:-}" ]; then
+	echo "${TAG} does not look like a maintenance release, just triggering merging forward."
+	echo "Deleting temporary tag"
+	git push origin :"$GITHUB_REF"
 else
-	# Create branch and PR for final release if necessary
+	if $SERVER_REPO && [ "$PATCH_NUMBER" == "0" ]; then
+		echo "Create non-SNAPSHOT branch in server repository for '.0' release"
+		git checkout -b "$RELEASE_BRANCH" "$GITHUB_SHA"
+		update_release_version
+		if ! git push -u origin "$RELEASE_BRANCH"; then
+			echo "Failed create ${RELEASE_BRANCH} for ${TAG}." >&2
+			exit 1
+		fi
+		echo "Move tag to release commit"
+		git tag --force "$TAG"
+		git push --force origin "$TAG"
 
-	# Make sure tag is valid
-	if ! $SERVER_REPO; then # Release branch is expected to be ahead of SNAPSHOT in server repo
-		RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "${GITHUB_SHA}..origin/${RELEASE_BRANCH}" | grep -v -e '^$')"
+	else
+		# Create branch and PR for final release if necessary
+
+		# Make sure tag is valid
+		if ! $SERVER_REPO; then # Release branch is expected to be ahead of SNAPSHOT in server repo
+			RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "${GITHUB_SHA}..origin/${RELEASE_BRANCH}" | grep -v -e '^$')"
+			echo ""
+			if [ -n "$RELEASE_DIFF" ]; then
+				echo "Improper release tag. ${TAG} is $(echo "$RELEASE_DIFF" | wc -l | xargs) commit(s) behind latest release." >&2
+				echo "$RELEASE_DIFF" >&2
+				exit 1
+			fi
+		fi
+		RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${SNAPSHOT_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
 		echo ""
 		if [ -n "$RELEASE_DIFF" ]; then
-			echo "Improper release tag. ${TAG} is $(echo "$RELEASE_DIFF" | wc -l | xargs) commit(s) behind latest release." >&2
+			echo "Improper release tag. ${TAG} is $(echo "$RELEASE_DIFF" | wc -l | xargs) commit(s) ahead of current snapshot branch." >&2
 			echo "$RELEASE_DIFF" >&2
 			exit 1
 		fi
-	fi
-	RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${SNAPSHOT_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
-	echo ""
-	if [ -n "$RELEASE_DIFF" ]; then
-		echo "Improper release tag. ${TAG} is $(echo "$RELEASE_DIFF" | wc -l | xargs) commit(s) ahead of current snapshot branch." >&2
-		echo "$RELEASE_DIFF" >&2
-		exit 1
+
+		RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${RELEASE_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
+		echo ""
+		# Create branch and PR for final release
+		if [ -z "${RELEASE_DIFF:-}" ] && ! $SERVER_REPO ; then
+			echo "No new changes for ${RELEASE_BRANCH} in ${TAG}."
+		else
+			echo "Create fast-forward branch for ${TAG}."
+			FF_BRANCH="${RELEASE_NUM}_ff_bot_${TAG}"
+			if $SERVER_REPO; then
+				# Merging changes from SNAPSHOT to release branch
+				if ! git checkout -b "$FF_BRANCH" --no-track origin/"$RELEASE_BRANCH" || ! git merge --no-commit "$GITHUB_SHA"; then
+					echo "Failed to create branch: ${FF_BRANCH}" >&2
+					exit 1
+				fi
+				update_release_version
+				if ! git push -u origin "$FF_BRANCH"; then
+					echo "Failed to push branch: ${FF_BRANCH}" >&2
+					exit 1
+				fi
+				# Move tag to actual release commit
+				git tag --force "$TAG"
+				git push --force origin "$TAG"
+			else
+				if ! hub api 'repos/{owner}/{repo}/git/refs' --raw-field "ref=refs/heads/${FF_BRANCH}" --raw-field "sha=${GITHUB_SHA}"; then
+					echo "Failed to create branch: ${FF_BRANCH}" >&2
+					exit 1
+				fi
+			fi
+			echo "Create pull request."
+			if ! pr_msg "Fast-forward for ${TAG}" \
+				"_Generated automatically._" \
+				"**Approve all matching PRs simultaneously.**" \
+				"**Approval will trigger automatic merge.**" \
+				"View all PRs: https://internal.labkey.com/Scrumtime/Backlog/harvest-gitOpenPullRequests.view?branch=${FF_BRANCH}" \
+				| hub pull-request -f -h "$FF_BRANCH" -b "$RELEASE_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER" -F -;
+			then
+				echo "Failed to create pull request for $FF_BRANCH" >&2
+				exit 1
+			fi
+		fi
 	fi
 
-	RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${RELEASE_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
-	echo ""
-	# Create branch and PR for final release
-	if [ -z "${PATCH_NUMBER:-}" ]; then
-		echo "${TAG} does not look like a patch release, just triggering merging forward."
-		echo "Deleting temporary tag"
-		git push origin :"$GITHUB_REF"
-	elif [ -z "${RELEASE_DIFF:-}" ] && ! $SERVER_REPO ; then
-		echo "No new changes for ${RELEASE_BRANCH} in ${TAG}."
-	else
-		echo "Create fast-forward branch for ${TAG}."
-		FF_BRANCH="${RELEASE_NUM}_ff_bot_${TAG}"
-		if $SERVER_REPO; then
-			# Merging changes from SNAPSHOT to release branch
-			if ! git checkout -b "$FF_BRANCH" --no-track origin/"$RELEASE_BRANCH" || ! git merge --no-commit "$GITHUB_SHA"; then
-				echo "Failed to create branch: ${FF_BRANCH}" >&2
-				exit 1
-			fi
-			update_release_version
-			if ! git push -u origin "$FF_BRANCH"; then
-				echo "Failed to push branch: ${FF_BRANCH}" >&2
-				exit 1
-			fi
-			# Move tag to actual release commit
-			git tag --force "$TAG"
-			git push --force origin "$TAG"
-		else
-			if ! hub api 'repos/{owner}/{repo}/git/refs' --raw-field "ref=refs/heads/${FF_BRANCH}" --raw-field "sha=${GITHUB_SHA}"; then
-				echo "Failed to create branch: ${FF_BRANCH}" >&2
-				exit 1
-			fi
-		fi
-		echo "Create pull request."
-		if ! pr_msg "Fast-forward for ${TAG}" \
-			"_Generated automatically._" \
-			"**Approve all matching PRs simultaneously.**" \
-			"**Approval will trigger automatic merge.**" \
-			"View all PRs: https://internal.labkey.com/Scrumtime/Backlog/harvest-gitOpenPullRequests.view?branch=${FF_BRANCH}" \
-			| hub pull-request -f -h "$FF_BRANCH" -b "$RELEASE_BRANCH" -a "$ASSIGNEE" -r "$REVIEWER" -F -;
-		then
-			echo "Failed to create pull request for $FF_BRANCH" >&2
-			exit 1
-		fi
-	fi
+	echo "Script complete for maintenance release ${TAG}"
+	exit 0
 fi
 
 # Determine next ESR release

--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -225,6 +225,7 @@ if [ -z "${PATCH_NUMBER:-}" ]; then
 	echo "${TAG} does not look like a maintenance release, just triggering merging forward."
 	echo "Deleting temporary tag"
 	git push origin :"$GITHUB_REF"
+
 else
 	if $SERVER_REPO && [ "$PATCH_NUMBER" == "0" ]; then
 		echo "Create non-SNAPSHOT branch in server repository for '.0' release"

--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -361,7 +361,7 @@ if hub api "repos/{owner}/{repo}/git/refs/heads/${MERGE_BRANCH}"; then
 	echo "${MERGE_BRANCH} is missing changes from new tag '${TAG}'. Previous merge forward was not resolved." >&2
 	echo "${MERGE_BRANCH} may be out of sync in other repositories." >&2
 	exit 1
-else
+fi
 
 echo ""
 echo "Merging ${TAG} to ${TARGET_BRANCH}"

--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -221,12 +221,10 @@ fi
 
 git fetch --unshallow || true
 
-if [ -z "${PATCH_NUMBER:-}" ]; then
-	echo "${TAG} does not look like a maintenance release, just triggering merging forward."
-	echo "Deleting temporary tag"
-	git push origin :"$GITHUB_REF"
+if [ -n "${PATCH_NUMBER:-}" ]; then
 
-else
+	echo "Creating maintenance release ${TAG}"
+
 	if $SERVER_REPO && [ "$PATCH_NUMBER" == "0" ]; then
 		echo "Create non-SNAPSHOT branch in server repository for '.0' release"
 		git checkout -b "$RELEASE_BRANCH" "$GITHUB_SHA"
@@ -304,6 +302,11 @@ else
 
 	echo "Script complete for maintenance release ${TAG}"
 	exit 0
+
+else
+	echo "${TAG} does not look like a maintenance release, just triggering merging forward."
+	echo "Deleting temporary tag"
+	git push origin :"$GITHUB_REF"
 fi
 
 # Determine next ESR release

--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -351,6 +351,18 @@ if [ -z "${MERGE_BRANCH:-}" ]; then
 	MERGE_BRANCH=fb_bot_merge_${RELEASE_NUM}
 fi
 
+if hub api "repos/{owner}/{repo}/git/refs/heads/${MERGE_BRANCH}"; then
+
+	RELEASE_DIFF="$(git log --cherry-pick --oneline --no-decorate "origin/${MERGE_BRANCH}..${GITHUB_SHA}" | grep -v -e '^$')"
+	if [ -z "${RELEASE_DIFF:-}" ]; then
+	    echo "${MERGE_BRANCH} already exists. Not going to attempt to merge forward."
+	    exit 0
+	fi
+	echo "${MERGE_BRANCH} is missing changes from new tag '${TAG}'. Previous merge forward was not resolved." >&2
+	echo "${MERGE_BRANCH} may be out of sync in other repositories." >&2
+	exit 1
+else
+
 echo ""
 echo "Merging ${TAG} to ${TARGET_BRANCH}"
 


### PR DESCRIPTION
#### Rationale
The release automation is triggered by TeamCity tagging repositories. A tag that was formatted like a maintenance release  (e.g. `22.3.4`) would create the maintenance release as well as merging forward to develop, otherwise (e.g. `22.3.Merge`) only the merge forward would be triggered.
Periodic merges forward are now triggered automatically by TeamCity. ~~In order to avoid colliding with manually triggered maintenance releases, we will make the merge forward distinct from the maintenance release process.~~
The script will continue to merge forward for maintenance releases but it will skip that step if a merge-forward branch already exists and throw an error if the existing branch is missing commits from the newly triggered merge.

#### Changes
* Skip merge-forward if a branch already exists
