### PR TITLE
Improve formatting of merge conflict advice

### DIFF
--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -409,7 +409,9 @@ else
 		"git checkout ${MERGE_BRANCH}" \
 		"git reset --hard origin/${TARGET_BRANCH}" \
 		"git merge ${GITHUB_SHA} -m \"Merge ${RELEASE_NUM} to ${NEXT_RELEASE}\"" \
-		"# resolve all conflicts" \
+		"\`\`\`" \
+		"Resolve all conflicts (using IntelliJ or \`git mergetool\`)" \
+		"\`\`\`" \
 		"git commit" \
 		"git push --force" \
 		"\`\`\`" \


### PR DESCRIPTION
#### Rationale
This breaks the instructions for resolving merge conflicts into two separate code blocks. This allows copying the merge commands with a single click on GitHub.

This is the new layout (note the copy button in the corner):
![image](https://github.com/LabKey/gitHubActions/assets/5263798/e8304e7f-f634-4dca-bd21-19b81ab05977)


#### Related Pull Requests
* N/A

#### Changes
* Improve formatting of merge conflict advice
