### PR TITLE
Fix regex for extracting version number from tag

### DIFF
--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -31,7 +31,7 @@ fi
 TAG="$( echo "$GITHUB_REF" | sed -e 's/refs\/tags\///' )"
 
 # Trim patch number from tag '19.3.11' => '19.3'
-RELEASE_NUM="$( echo "$TAG" | grep -oE '([0-9]+\.[0-9]+)' )"
+RELEASE_NUM="$( echo "$TAG" | grep -oE '(^[0-9]+\.[0-9]+)' )"
 
 if [ -z "${RELEASE_NUM:-}" ]; then
 	echo "Tag does not appear to be for a release: ${TAG}" >&2


### PR DESCRIPTION
#### Rationale
We want to support special tags to merge changes into monthly release branches:
```
╰─$ echo $TAG
26.3._26.4
```

Having two different version numbers in the release tag is throwing off the logic that determines the release version:
```
╰─$ echo "$TAG" | grep -oE '([0-9]+\.[0-9]+)'
26.3
26.4
```

Limiting it to the beginning of the tag does the trick:
```
╰─$ echo "$TAG" | grep -oE '(^[0-9]+\.[0-9]+)'
26.3
```

#### Related Pull Requests
* https://github.com/LabKey/gitHubActions/pull/27

#### Changes
* Fix regex for extracting version number from tag
