### PR TITLE
Fix PR title and commit message for merge override

### DIFF
--- a/branch-release/branch_release.sh
+++ b/branch-release/branch_release.sh
@@ -317,10 +317,11 @@ esac
 
 
 if [ -n "${FORCED_TARGET_RELEASE:-}" ]; then
-    TARGET_BRANCH=release${FORCED_TARGET_RELEASE}-SNAPSHOT
+	NEXT_RELEASE=${FORCED_TARGET_RELEASE}
+    TARGET_BRANCH=release${NEXT_RELEASE}-SNAPSHOT
 	if git rev-parse --verify --quiet "refs/remotes/origin/${TARGET_BRANCH}"; then
         echo ""
-        echo "Overriding default merge forward target with '${TARGET_BRANCH}'. Merging ${TAG} to it."
+        echo "Overriding default merge forward target with '${TARGET_BRANCH}'. Merging tag ${TAG} to it."
 		MERGE_BRANCH="${FORCED_TARGET_RELEASE}_fb_bot_merge_${RELEASE_NUM}"
 	else
 	    echo "The created tag '${TAG}' specified an invalid target release override: ${TARGET_BRANCH}." >&2


### PR DESCRIPTION
#### Rationale
The PR and commit use the defined `NEXT_RELEASE`. The script should set it when the target release has been overridden. Otherwise the next ESR release will be used (even if it doesn't actually exist).

#### Related Pull Requests
* #27 
* https://github.com/LabKey/platform/pull/7604

#### Changes
* Fix PR title and commit message for merge override
